### PR TITLE
`npm-check-updates -a` for nunjucks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.npm/

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   "author": "AKFish <akfish@gmail.com> (http://catx.me)",
   "license": "MIT",
   "dependencies": {
-    "bluebird": "^2.9.25",
-    "hexo-fs": "^0.1.3",
-    "less": "^2.5.0",
-    "nunjucks": "^1.3.4"
+    "bluebird": "^3.5.0",
+    "hexo-fs": "^0.2.1",
+    "less": "^2.7.2",
+    "nunjucks": "^3.0.1"
   }
 }


### PR DESCRIPTION
`nunjucks@^1.3.4` dependents `fs@0.3.8` which is deprecated. Update to `nunjucks@^3.0.1` is required.